### PR TITLE
Adds tini

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build:
       context: ./docker-config/nginx
       dockerfile: ./Dockerfile
+    init: true
     env_file: &env
       - ./cms/.env
     links:
@@ -20,6 +21,7 @@ services:
     build:
       context: ./docker-config/php-dev-craft
       dockerfile: ./Dockerfile
+    init: true
     depends_on:
       - "postgres"
       - "redis"
@@ -41,6 +43,7 @@ services:
     build:
       context: ./docker-config/postgres
       dockerfile: ./Dockerfile
+    init: true
     env_file:
       *env
     environment:
@@ -56,6 +59,7 @@ services:
     build:
       context: ./docker-config/redis
       dockerfile: ./Dockerfile
+    init: true
     expose:
       - "6379"
   # webpack - frontend build system
@@ -63,6 +67,7 @@ services:
     build:
       context: ./docker-config/node-dev-webpack
       dockerfile: ./Dockerfile
+    init: true
     env_file:
       *env
     ports:


### PR DESCRIPTION
https://docs.docker.com/compose/compose-file/#init / https://github.com/krallin/tini

Adds tini for sigterm forwarding (currently webpack and php-fpm aren't receiving them, and after a timeout they are sigkill'ed), as well as zombie reaping