### PR TITLE
Add Privacy Policy & TOS

### DIFF
--- a/cms/templates/_partials/info-footer.twig
+++ b/cms/templates/_partials/info-footer.twig
@@ -12,9 +12,7 @@
                 // Site by<a class="navbar-link font-mono text-sm" href="https://nystudio107.com/" target="_blank" rel="noopener">nystudio107.com</a>designed by<a class="navbar-link font-mono text-sm" href="https://codemdd.io/" target="_blank" rel="noopener">codemdd.io</a></span>
                 <br />
                 <br />
-                {% verbatim %}
-                    <span class="whitespace-no-wrap not-italic">{{ footer.privacyPolicy }}</span> <span class="whitespace-no-wrap not-italic">{{ footer.termsOfService }}</span>
-                {% endverbatim %}
+                <span class="whitespace-no-wrap not-italic">{{ footer.privacyPolicy }}</span> <span class="whitespace-no-wrap not-italic">{{ footer.termsOfService }}</span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The use of `{% verbatim %}` here makes the Twig code appear literally and does not actually parse the Twig tags. This prevents the display of links to the website Privacy Policy & TOS. I have assumed you have already added `footer` as a global variable, if not please update the commit accordingly. 

Thanks!