### PR TITLE
updated buddy to match with alpine update

### DIFF
--- a/buddy.yml
+++ b/buddy.yml
@@ -29,7 +29,7 @@
         - "composer install --no-scripts --no-interaction --prefer-dist --optimize-autoloader --ignore-platform-reqs"
       setup_commands:
         - "echo \"memory_limit=-1\" >> /usr/local/etc/php/conf.d/buddy.ini"
-        - "apt-get update && apt-get install -y git zip"
+        - "apk update && apk add git zip"
         - "curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer"
         - "# php ext pdo_mysql"
         - "docker-php-ext-install pdo_pgsql pgsql"


### PR DESCRIPTION
### Description

Buddy builds would fail as it couldn't find `apt-get` anymore, since the latest container of `php-dev-craft` now runs on alpine had to change the commands to `apk update` and `apk add` 
