### PR TITLE
Fix critical css settings

### DIFF
--- a/buildchain/webpack-settings/critical.settings.js
+++ b/buildchain/webpack-settings/critical.settings.js
@@ -12,39 +12,39 @@ module.exports = {
         criticalWidth: 1200,
         pages: [
             {
-                url: '',
+                uri: '',
                 template: 'index'
             },
             {
-                url: 'about',
+                uri: 'about',
                 template: 'about/index'
             },
             {
-                url: 'calendar',
+                uri: 'calendar',
                 template: 'calendar/index'
             },
             {
-                url: 'episodes',
+                uri: 'episodes',
                 template: 'episodes/index'
             },
             {
-                url: 'episodes/webpack-inside-out-with-sean-larkin',
+                uri: 'episodes/webpack-inside-out-with-sean-larkin',
                 template: 'episodes/_entry'
             },
             {
-                url: 'errors/offline',
+                uri: 'errors/offline',
                 template: 'errors/offline'
             },
             {
-                url: 'errors/error',
+                uri: 'errors/error',
                 template: 'errors/error'
             },
             {
-                url: 'errors/503',
+                uri: 'errors/503',
                 template: 'errors/503'
             },
             {
-                url: 'errors/404',
+                uri: 'errors/404',
                 template: 'errors/404'
             },
         ]


### PR DESCRIPTION
### Description

`settings.url` should be `uri` like reference in https://github.com/nystudio107/devmode/blob/f2b231e772026860f75e255c9e22722dac983de8/buildchain/webpack-configs/critical.config.js#L11.

### Related issues

Let me know if you need a linked issue as well.