### PR TITLE
[WIP] Add support docker compose plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # nystudio107/devmode Change Log
 
+## 2.6.6 - 2022.07.30
+### Added
+* Added `docker compose` plugin support
+
 ## 2.6.5 - 2022.05.04
 ### Added
 * Determine the container name separator character by checking the Docker Compose API version at runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.6.6 - 2022.07.30
 ### Added
 * Added `docker compose` plugin support
+* Suppressed .env copy operating from console output
 
 ## 2.6.5 - 2022.05.04
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
 # Determine the docker compose API version to get the separator character
-VERSION?=$(shell docker-compose -v)
-ifneq (,$(findstring v2.,$(VERSION)))
-	SEPARATOR:=-
+SEPARATOR:=_
+DOCKER_COMPOSE_CMD=docker-compose
+ifeq (, $(shell which docker-compose))
+    ifneq (,$(findstring Docker Compose version,$(shell docker compose version)))
+        DOCKER_COMPOSE_CMD=docker compose
+    else
+        $(error "No docker compose plugin installed, install either docker-compose or docker-compose-plugin")
+    endif
 else
-	SEPARATOR:=_
+    VERSION?=$(shell docker-compose -v)
+    ifneq (,$(findstring v2.,$(VERSION)))
+        SEPARATOR:=-
+    endif
 endif
+
 CONTAINER?=$(shell basename $(CURDIR))$(SEPARATOR)php$(SEPARATOR)1
 BUILDCHAIN?=$(shell basename $(CURDIR))$(SEPARATOR)vite$(SEPARATOR)1
 
@@ -40,15 +49,15 @@ restoredb: up
 		$(filter-out $@,$(MAKECMDGOALS))
 # Remove the Docker volumes & start clean
 nuke: clean
-	docker-compose down -v
-	docker-compose up --build --force-recreate
+	$(DOCKER_COMPOSE_CMD) down -v
+	$(DOCKER_COMPOSE_CMD) up --build --force-recreate
 # Open up a shell in the PHP container
 ssh:
 	docker exec -it $(CONTAINER) su-exec www-data /bin/sh
 up:
 	if [ ! "$$(docker ps -q -f name=$(CONTAINER))" ]; then \
 		cp -n cms/example.env cms/.env; \
-		docker-compose up; \
+		$(DOCKER_COMPOSE_CMD) up; \
     fi
 %:
 	@:

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ nuke: clean
 ssh:
 	docker exec -it $(CONTAINER) su-exec www-data /bin/sh
 up:
-	if [ ! "$$(docker ps -q -f name=$(CONTAINER))" ]; then \
+	@if [ ! "$$(docker ps -q -f name=$(CONTAINER))" ]; then \
 		cp -n cms/example.env cms/.env; \
 		$(DOCKER_COMPOSE_CMD) up; \
     fi


### PR DESCRIPTION
### Description
I am using the new docker compose plugin `docker-compose-plugin` which comes bundled with docker when installing the latest version. This does not require you to install the `docker-compose` plugin manually and works as part of the `docker` command.

**Notes**

- This change will primarily aim to use `docker-compose` which gives me the feeling it's less of an impact.
- I cannot test this for backwards compatibility as I don't have the `docker-compose` library anymore, _please test_.

The Makefile for this project expects to use the `docker-compose` command to bring up the project. 
I've added checks to determine if we can use `docker-compose` which will in turn check the docker compose API version to determine the separator (existing functionality).

In case `docker-compose` was not found it will check for the `docker compose` plugin and will throw an error and exit the program if this is also not found.

Some changes I made:

- Default the `SEPARATOR` var to `_`, which will only be overwritten to `-` in case you are using a older version of `docker-compose`. The **assumption** here is that the new docker compose plugin defaults to v2 or higher.
- Introduced `DOCKER_COMPOSE_CMD`. Defaults to `docker-compose`, will be overwritten if `docker-compose` is not found and the `docker compose` plugin is detected.
- Suppress .env file operation output from the console.


### Related issues
None

## Todo

- [x] (Not applicable) Ensure any install or build dependencies are removed before the end of the layer when doing a build. 
- [x] Update the CHANGELOG.md with details of changes to the project.
- [x] (Not applicable) If applicable, update the README.md or associated documentation to cover the changes to the project.
- [ ] Test backwards compatibility with `docker-compose`
